### PR TITLE
Worker-based Async API with await/Promise support (or plain callbacks)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+build
+deps
+node_modules
+tsc-lib

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,25 +1,25 @@
 module.exports = {
-    root: true,
-    "env": {
-        "commonjs": true,
-        "es2020": true,
-        "node": true,
-        "jasmine": true
-    },
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
-        "plugin:jasmine/recommended"
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": 11
-    },
-    "plugins": ["@typescript-eslint", "jasmine"],
-    "rules": {
-        "indent": ["error", 2],
-        "semi": "error",
-        "@typescript-eslint/no-var-requires": 0,
-        "no-constant-condition": 0
-    }
+  root: true,
+  "env": {
+    "commonjs": true,
+    "es2020": true,
+    "node": true,
+    "jasmine": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:jasmine/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 11
+  },
+  "plugins": ["@typescript-eslint", "jasmine"],
+  "rules": {
+    "indent": ["error", 2],
+    "semi": "error",
+    "@typescript-eslint/no-var-requires": 0,
+    "no-constant-condition": 0
+  }
 };

--- a/examples/async-srt-await.js
+++ b/examples/async-srt-await.js
@@ -22,4 +22,4 @@ async function awaitConnections(socket) {
 
 setInterval(() => {
   console.log('Doing other stuff in the meantime ... :)');
-}, 1000)
+}, 1000);

--- a/examples/async-srt-await.js
+++ b/examples/async-srt-await.js
@@ -1,0 +1,25 @@
+const { AsyncSRT } = require('../src/async.js');
+
+const asyncSrt = new AsyncSRT();
+
+(async function() {
+  const socket = await asyncSrt.createSocket(false);
+  console.log('createSocket() result:', socket);
+  let result = await asyncSrt.bind(socket, "0.0.0.0", 1234);
+  console.log('bind() result:', result);
+  result = await asyncSrt.listen(socket, 2);
+  console.log('listen() result:', result);
+
+  awaitConnections(socket);
+
+})();
+
+async function awaitConnections(socket) {
+  console.log('Awaiting incoming client connection ...');
+  const fd = await asyncSrt.accept(socket);
+  console.log('New incoming client fd:', fd);
+}
+
+setInterval(() => {
+  console.log('Doing other stuff in the meantime ... :)');
+}, 1000)

--- a/examples/async-srt-promises.js
+++ b/examples/async-srt-promises.js
@@ -1,0 +1,32 @@
+"use strict";
+
+const { AsyncSRT } = require('../src/async.js');
+
+const asyncSrt = new AsyncSRT();
+
+let mySocket;
+
+asyncSrt.createSocket(false)
+  .catch((err) => console.error(err))
+  .then((result) => {
+    console.log('createSocket:', result);
+    mySocket = result;
+    return result;
+  })
+  .then((socket) => asyncSrt.bind(socket, "0.0.0.0", 1234))
+  .then((result) => {
+    if (result !== 0) {
+      throw new Error('Failed bind');
+    }
+    console.log('Bind success');
+    return asyncSrt.listen(mySocket, 2);
+  })
+  .then((result) => {
+    if (!result) {
+      console.log("Listen success");
+    } else {
+      throw new Error('SRT listen error: ' + result);
+    }
+  });
+
+

--- a/examples/async-srt.js
+++ b/examples/async-srt.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const { AsyncSRT } = require('../src/async.js');
+
+const asyncSrt = new AsyncSRT();
+
+asyncSrt.createSocket(false, (result) => {
+  console.log('createSocket:', result);
+  const socket = result;
+  asyncSrt.bind(socket, "0.0.0.0", 1234, (result) => {
+    if (result !== 0) {
+      console.log('Failed bind');
+    } else {
+      console.log('Bind success');
+      asyncSrt.listen(socket, 2, (result) => {
+        if (!result) {
+          console.log("Listen success");
+        } else {
+          console.log(result);
+        }
+      });
+    }
+  });
+});
+

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,5 +2,6 @@
 /// <reference path="./types/srt-api.d.ts" />
 /// <reference path="./types/srt-stream.d.ts" />
 /// <reference path="./types/srt-server.d.ts" />
+/// <reference path="./types/srt-api-async.d.ts" />
 
 export * from "srt";

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/triple-slash-reference */
 /// <reference path="./types/srt-api.d.ts" />
 /// <reference path="./types/srt-stream.d.ts" />
 /// <reference path="./types/srt-server.d.ts" />

--- a/index.js
+++ b/index.js
@@ -7,4 +7,4 @@ module.exports = {
   Server: Server,
   SRTReadStream,
   SRTWriteStream
-}
+};

--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
-const LIB = require('./build/Release/node_srt.node');
+const { SRT } = require('./build/Release/node_srt.node');
 const Server = require('./src/server.js');
 const { SRTReadStream, SRTWriteStream } = require('./src/stream.js');
+const { AsyncSRT } = require('./src/async');
 
 module.exports = {
-  SRT: LIB.SRT,
-  Server: Server,
+  SRT,
+  Server,
   SRTReadStream,
-  SRTWriteStream
+  SRTWriteStream,
+  AsyncSRT,
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "rebuild": "node-gyp rebuild",
     "clean": "node-gyp clean",
     "test": "$(npm bin)/jasmine",
-    "lint": "eslint src examples types --ext .js --ext .ts",
+    "lint": "eslint . --ext .js --ext .ts",
     "check-tsc": "./node_modules/.bin/tsc examples/srt.ts --outDir ./tsc-lib",
     "postversion": "git push && git push --tags"
   },

--- a/src/async-worker.js
+++ b/src/async-worker.js
@@ -1,0 +1,41 @@
+const {
+  Worker, isMainThread, parentPort, workerData
+} = require('worker_threads');
+
+const { SRT } = require('../build/Release/node_srt.node');
+
+if (isMainThread) {
+  throw new Error("Worker module can not load on main thread");
+}
+
+(function run() {
+  const libSRT = new SRT();
+  parentPort.on('message', (data) => {
+    if (!data.method) {
+      throw new Error('Worker message needs `method` property');
+    }
+    /*
+    if (!data.workId) {
+      throw new Error('Worker message needs `workId` property');
+    }
+    */
+    let result = libSRT[data.method].apply(libSRT, data.args);
+    // TODO: see if we can do this using SharedArrayBuffer for example,
+    //       or just leveraging Transferable objects capabilities ... ?
+    // FIXME: Performance ... ?
+    if (result instanceof Buffer) {
+      const buf = Buffer.allocUnsafe(result.length);
+      result.copy(buf);
+      result = buf;
+    }
+    parentPort.postMessage({
+      // workId: data.workId,
+      timestamp: data.timestamp,
+      result
+    });
+  });
+})();
+
+
+
+

--- a/src/async.js
+++ b/src/async.js
@@ -3,7 +3,6 @@ const {
 } = require('worker_threads');
 
 const path = require('path');
-
 const {performance} = require("perf_hooks");
 
 const DEFAULT_PROMISE_TIMEOUT_MS = 3000;
@@ -30,6 +29,10 @@ class AsyncSRT {
     this._workCbQueue = [];
   }
 
+  /**
+   * @private
+   * @param {*} data
+   */
   _onWorkerMessage(data) {
     const resolveTime = performance.now();
     const {timestamp, result, workId} = data;
@@ -38,6 +41,12 @@ class AsyncSRT {
     callback(result);
   }
 
+  /**
+   * @private
+   * @param {string} method
+   * @param {Array<any>} args
+   * @param {Function} callback
+   */
   _postAsyncWork(method, args, callback) {
     const timestamp = performance.now();
 
@@ -59,9 +68,9 @@ class AsyncSRT {
   }
 
   /**
-   *
+   * @private
    * @param {string} method
-   * @param {Array} args optional
+   * @param {Array<any>} args optional
    * @param {Function} callback optional
    */
   _createAsyncWorkPromise(method, args = [], callback = null, useTimeout = true, timeoutMs = AsyncSRT.TimeoutMs) {

--- a/src/async.js
+++ b/src/async.js
@@ -206,7 +206,7 @@ class AsyncSRT {
    * @param msTimeOut
    */
   epollUWait(epid, msTimeOut, callback) {
-    return this._createAsyncWorkPromise("epollAddUsock", [epid, msTimeOut], callback);
+    return this._createAsyncWorkPromise("epollUWait", [epid, msTimeOut], callback);
   }
 }
 

--- a/src/async.js
+++ b/src/async.js
@@ -28,7 +28,6 @@ class AsyncSRT {
     this._workCbMap = new Map();
     */
     this._workCbQueue = [];
-    this._workCbListRejected = [];
   }
 
   _onWorkerMessage(data) {

--- a/src/async.js
+++ b/src/async.js
@@ -1,0 +1,219 @@
+const {
+  Worker, isMainThread, parentPort, workerData
+} = require('worker_threads');
+
+const path = require('path');
+
+const {performance} = require("perf_hooks");
+
+const PROMISE_TIMEOUT_MS = 3000;
+
+/*
+const WORK_ID_GEN_MOD = 0xFFF;
+*/
+
+class AsyncSRT {
+
+  constructor() {
+    this._worker = new Worker(path.resolve(__dirname, './async-worker.js'));
+    this._worker.on('message', this._onWorkerMessage.bind(this));
+    /*
+    this._workIdGen = 0;
+    this._workCbMap = new Map();
+    */
+    this._workCbQueue = [];
+  }
+
+  _onWorkerMessage(data) {
+    const resolveTime = performance.now();
+    const {timestamp, result, workId} = data;
+
+    const callback = this._workCbQueue.shift();
+    callback(result);
+  }
+
+  _postAsyncWork(method, args, callback) {
+    const timestamp = performance.now();
+
+    // not really needed atm,
+    // only if the worker spawns async jobs itself internally
+    // and thus the queuing order of jobs would not be preserved
+    // across here and the worker side.
+    /*
+    if (this._workCbMap.size >= WORK_ID_GEN_MOD - 1) {
+      throw new Error('Can`t post more async work: Too many awaited callbacks unanswered in queue');
+    }
+    const workId = this._workIdGen;
+    this._workIdGen = (this._workIdGen + 1) % WORK_ID_GEN_MOD;
+    this._workCbMap.set(workId, callback);
+    */
+
+    this._workCbQueue.push(callback);
+    this._worker.postMessage({method, args, /*workId,*/ timestamp});
+  }
+
+  /**
+   *
+   * @param {string} method
+   * @param {Array} args optional
+   * @param {Function} callback optional
+   */
+  _createAsyncWorkPromise(method, args = [], callback = null, useTimeout = true) {
+    return new Promise((resolve, reject) => {
+      let timeout;
+      if (useTimeout) {
+        timeout = setTimeout(() => {
+          reject(new Error('Timeout exceeded while awaiting result from worker running native-addon module functions'));
+        }, PROMISE_TIMEOUT_MS);
+      }
+      const onResult = (result) => {
+        if (useTimeout) clearTimeout(timeout);
+        resolve(result);
+        if (callback) callback(result); // NOTE: the order doesn't matter for us,
+        //      but intuitively the promise result should probably be resolved first.
+      };
+      this._postAsyncWork(method, args, onResult);
+    });
+  }
+
+  /**
+   *
+   * @param {boolean} sender
+   * @returns SRTSOCKET identifier (integer value) or -1 (SRT_ERROR)
+   */
+  createSocket(sender, callback) {
+    return this._createAsyncWorkPromise("createSocket", [sender], callback);
+  }
+
+  /**
+   *
+   * @param socket
+   * @param address
+   * @param port
+   */
+  bind(socket, address, port, callback) {
+    return this._createAsyncWorkPromise("bind", [socket, address, port], callback);
+  }
+
+  /**
+   *
+   * @param socket
+   * @param backlog
+   */
+  listen(socket, backlog, callback) {
+    return this._createAsyncWorkPromise("listen", [socket, backlog], callback);
+  }
+
+  /**
+   *
+   * @param socket
+   * @param host
+   * @param port
+   */
+  connect(socket, host, port, callback) {
+    return this._createAsyncWorkPromise("connect", [socket, host, port], callback);
+  }
+
+  /**
+   *
+   * @param socket
+   * @returns File descriptor of incoming connection pipe
+   */
+  accept(socket, callback) {
+    return this._createAsyncWorkPromise("accept", [socket], callback, false);
+  }
+
+  /**
+   *
+   * @param socket
+   */
+  close(socket, callback) {
+    return this._createAsyncWorkPromise("close", [socket], callback);
+  }
+
+  /**
+   *
+   * @param socket
+   * @param chunkSize
+   * @returns {Promise<Buffer>}
+   */
+  read(socket, chunkSize, callback) {
+    return this._createAsyncWorkPromise("read", [socket, chunkSize], callback);
+  }
+
+  /**
+   *
+   * @param socket
+   * @param {Buffer} chunk
+   */
+  write(socket, chunk, callback) {
+    // TODO: see if we can do this using SharedArrayBuffer for example,
+    //       or just leveraging Transferable objects capabilities ... ?
+    // FIXME: Performance ... ?
+    const buf = Buffer.allocUnsafe(chunk.length);
+    chunk.copy(buf);
+    chunk = buf;
+    return this._createAsyncWorkPromise("write", [socket, chunk], callback);
+  }
+
+  /**
+   *
+   * @param socket
+   * @param option
+   * @param value
+   */
+  setSockOpt(socket, option, value, callback) {
+    return this._createAsyncWorkPromise("setSockOpt", [socket, option, value], callback);
+  }
+
+  /**
+   *
+   * @param socket
+   * @param option
+   */
+  getSockOpt(socket, option, callback) {
+    return this._createAsyncWorkPromise("getSockOpt", [socket, option], callback);
+  }
+
+  /**
+   *
+   * @param socket
+   */
+  getSockState(socket, callback) {
+    return this._createAsyncWorkPromise("getSockState", [socket], callback);
+  }
+
+  /**
+   * @returns epid
+   */
+  epollCreate(callback) {
+    return this._createAsyncWorkPromise("epollCreate", [], callback);
+  }
+
+  /**
+   *
+   * @param epid
+   * @param socket
+   * @param events
+   */
+  epollAddUsock(epid, socket, events, callback) {
+    return this._createAsyncWorkPromise("epollAddUsock", [epid, socket, events], callback);
+  }
+
+  /**
+   *
+   * @param epid
+   * @param msTimeOut
+   */
+  epollUWait(epid, msTimeOut, callback) {
+    return this._createAsyncWorkPromise("epollAddUsock", [epid, msTimeOut], callback);
+  }
+}
+
+module.exports = {AsyncSRT};
+
+
+
+
+
+

--- a/src/async.js
+++ b/src/async.js
@@ -6,13 +6,19 @@ const path = require('path');
 
 const {performance} = require("perf_hooks");
 
-const PROMISE_TIMEOUT_MS = 3000;
+const DEFAULT_PROMISE_TIMEOUT_MS = 3000;
 
 /*
 const WORK_ID_GEN_MOD = 0xFFF;
 */
 
 class AsyncSRT {
+
+  /**
+   * @static
+   * @type {number} Promise-timeout in millis
+   */
+  static TimeoutMs = DEFAULT_PROMISE_TIMEOUT_MS;
 
   constructor() {
     this._worker = new Worker(path.resolve(__dirname, './async-worker.js'));
@@ -119,8 +125,8 @@ class AsyncSRT {
    * @param socket
    * @returns File descriptor of incoming connection pipe
    */
-  accept(socket, callback) {
-    return this._createAsyncWorkPromise("accept", [socket], callback, false);
+  accept(socket, callback, useTimeout = false, timeoutMs = AsyncSRT.TimeoutMs) {
+    return this._createAsyncWorkPromise("accept", [socket], callback, useTimeout, timeoutMs);
   }
 
   /**

--- a/types/srt-api-async.d.ts
+++ b/types/srt-api-async.d.ts
@@ -1,0 +1,107 @@
+declare module "srt" {
+
+  type AsyncSRTCallback<T> = (result: T) => void;
+
+  class AsyncSRT {
+
+    static TimeoutMs: number;
+
+    /**
+     *
+     * @param sender
+     * @returns SRTSOCKET identifier (integer value)
+     */
+    createSocket(sender: boolean, callback?: AsyncSRTCallback<number>): Promise<number>
+
+    /**
+     *
+     * @param socket
+     * @param address
+     * @param port
+     */
+    bind(socket: number, address: string, port: number, callback?: AsyncSRTCallback<SRTResult>): Promise<SRTResult>
+
+    /**
+     *
+     * @param socket
+     * @param backlog
+     */
+    listen(socket: number, backlog: number, callback?: AsyncSRTCallback<SRTResult>): Promise<SRTResult>
+
+    /**
+     *
+     * @param socket
+     * @param host
+     * @param port
+     */
+    connect(socket: number, host: string, port: number, callback?: AsyncSRTCallback<SRTResult>): Promise<SRTResult>
+
+    /**
+     *
+     * @param socket
+     * @returns File descriptor of incoming connection pipe
+     */
+    accept(socket: number, callback?: AsyncSRTCallback<SRTFileDescriptor>): Promise<SRTFileDescriptor>
+
+    /**
+     *
+     * @param socket
+     */
+    close(socket: number, callback?: AsyncSRTCallback<SRTResult>): Promise<SRTResult>
+
+    /**
+     *
+     * @param socket
+     * @param chunkSize
+     */
+    read(socket: number, chunkSize: number, callback?: AsyncSRTCallback<SRTReadReturn>): Promise<SRTReadReturn>
+
+    /**
+     *
+     * @param socket
+     * @param chunk
+     */
+    write(socket: number, chunk: Buffer, callback?: AsyncSRTCallback<SRTResult>): Promise<SRTResult>
+
+    /**
+     *
+     * @param socket
+     * @param option
+     * @param value
+     */
+    setSockOpt(socket: number, option: SRTSockOpt, value: SRTSockOptValue, callback?: AsyncSRTCallback<SRTResult>): Promise<SRTResult>
+
+    /**
+     *
+     * @param socket
+     * @param option
+     */
+    getSockOpt(socket: number, option: SRTSockOpt, callback?: AsyncSRTCallback<SRTSockOptValue>): Promise<SRTSockOptValue>
+
+    /**
+     *
+     * @param socket
+     */
+    getSockState(socket: number, callback?: AsyncSRTCallback<SRTSockStatus>): Promise<SRTSockStatus>
+
+    /**
+     * @returns epid
+     */
+    epollCreate(callback?: AsyncSRTCallback<number>): Promise<number>
+
+    /**
+     *
+     * @param epid
+     * @param socket
+     * @param events
+     */
+    epollAddUsock(epid: number, socket: number, events: number, callback?: AsyncSRTCallback<SRTResult>): Promise<SRTResult>
+
+    /**
+     *
+     * @param epid
+     * @param msTimeOut
+     */
+    epollUWait(epid: number, msTimeOut: number, callback?: AsyncSRTCallback<SRTEpollEvent[]>): Promise<SRTEpollEvent[]>
+  }
+}

--- a/types/srt-api.d.ts
+++ b/types/srt-api.d.ts
@@ -48,7 +48,7 @@ declare module "srt" {
      * @param socket
      * @param chunkSize
      */
-    read(socket: number, chunkSize: number): Buffer
+    read(socket: number, chunkSize: number): SRTReadReturn
 
     /**
      *
@@ -63,14 +63,14 @@ declare module "srt" {
      * @param option
      * @param value
      */
-    setSockOpt(socket: number, option: number, value: SRTSocketOptValue): number
+    setSockOpt(socket: number, option: SRTSockOpt, value: SRTSockOptValue): SRTResult
 
     /**
      *
      * @param socket
      * @param option
      */
-    getSockOpt(socket: number, option: number): SRTSocketOptValue
+    getSockOpt(socket: number, option: SRTSockOpt): SRTSockOptValue
 
     /**
      *
@@ -96,17 +96,19 @@ declare module "srt" {
      * @param epid
      * @param msTimeOut
      */
-    epollUWait(epid: number, msTimeOut: number): SRTPollingEvent[]
+    epollUWait(epid: number, msTimeOut: number): SRTEpollEvent[]
   }
 
-  interface SRTPollingEvent {
+  interface SRTEpollEvent {
     socket: SRTFileDescriptor
     events: number
   }
 
+  type SRTReadReturn = Buffer | SRTResult.SRT_ERROR | null
+
   type SRTFileDescriptor = number;
 
-  type SRTSocketOptValue = boolean | number | string
+  type SRTSockOptValue = boolean | number | string
 
   enum SRTResult {
     SRT_ERROR = -1,


### PR DESCRIPTION
I would like to explain a bit how I thought about the pros/cons of doing it like this or another way, why I think this is necessary, and what I would envision in terms of usage possibilities and trade-offs for this Node.js binding to libSRT in the future.

# Problem

The current N-API binding layer to libSRT is such that every native call, which are all blocking I/O, runs synchroneously with the wrapping JS function call. 

This specific making design of the bindings certainly has advantages, but comes with some usage issues on the JS side as these functions are called from the Node.js proc main-thread / event loop. 

As we are trying to achieve higher througputs reading/writing to SRT file-descriptors takes a while. For example, if we read/write 16kbytes from a socket per one JS main thread tick every 20ms, that’s just about 6,4 Mbit/s throughput. That means that we only have this window of 20ms between every call to do other tasks, which is smaller as the r/w operation takes time itself.

Awaiting incoming connections in `accept` mode to implement a server is "tricky" with this sort of blocking API from a JS application point of view (see the current ReadableStream and Server implementations). 

Also any other blocking SRT operation done will generally impact application performance in an unpredictable way, as other tasks our Node.js service may run in production will backlog waiting for our sync'd binding to return. Generally, running blocking I/O directly on the JS main loop is a source of issues and considered bad practice for reasons better explained in a "theory" section I wrote up below (but feel free to TLDR that if you agree so far).

# Solution

To solve this problem, we run the native calls into libSRT i.e the blocking binding methods on a JS Worker thread. The architecture used here is doing generic RPC'ing from a "proxy" class. To do this, the proxy class reflects the method names & signatures of the bindings JS API that we are calling in the Worker message-queue iterations. The proxy class calls a generic function to pass all argument as an array and the method name itself as litteral string value in a message to the worker (like in an RPC, where the remote end here is the other thread running the actual SRT API bindings).

The herewith introduced `AsyncSRT` class which implements this proxy has also the same API as the current version, with a callback function argument added on every method, and each returns a Promise of the result value that the sync API would return. 

* A proxy class instance owns a worker thread instance each and allows therefore to manage queued RPC's and respective results/callbacks to one "SRT thread" each. Concurrent access to underlying native sockets/file-descriptors via libSRT is thus possible in a managed way (for example one thread may accept new connections, while another worker can perform read/write ops on FDs).

* This is relatively simple to implement here as you can see, as since the SRT calls are all blocking and no other thread does anything event-loopish and it is all polling etc, the queuing/dequeuing order of RPCs/callbacks between main<->worker threads is fully maintained. 

* You can also run the SRT async API i.e spawn the worker thread from another parent worker btw, that's all the same to it.

* Potentially out-of-order RPC-back/result-dequeuing is possible with a type of call-ID generator and callback-map that we prototyped (but not used atm since the worker is only doing sync/blocking internally with the current SRT lib binding).

* Any user passed callback is wraped in the `new Promise` executor, in which the actual worker message-posting is called. The Promise resolver is the corresponding result message from the worker, and it will call both `Promise.resolve` and the plain callback, if any was passed at all (that is optional). By design choice it will get called after the resolve function, but that only plays a role if you want to use both callbacks and Promises- which is a rather rare case.

* Every promise returned has a timeout which defaults to 3000 ms. We could make this configurable at runtime for all the bindings module, or even allow to pass in an optional timeout value on each async API method in principle. If the timeout is exceeded, the promise gets rejected.

* The `accept` method is the only one which does not use/need a timeout, for obvious reasons. Important to note here, see "Worker Termination" in the issues section ...

# Issues (new or remaining)

## Zero-copy

Atm we are doing a copy of `Buffer` objects across (for read/write methods), as sharing/message-passing buffer refs is otherwise non trivial or illegal with `Worker`s. This is far from ideal way to handle this. In principle, there are several possible solutions to make this zero-copy (see `SharedArrayBuffer` or `Transferable` objects). But these lay some constraints onto the application using them. So we want to make copy the default mode, and allow to enable others by configuration (in further patches).

## `Worker` overhead 

The JS `Worker` as a light-weight thread-abstraction makes this solution very easy to implement. However, it certainly will have a different performance overhead (and other constraints in handling dataflow- see zero-copy) due to being in JS land as opposed to C/N-API land. 

## `accept` & Worker Termination

There is atm no way to "cancel" a once posted "accept job". This SRT function call effectively blocks the worker thread until any client connects on a listened socket. Addings such a helper as a feature might be interesting, as one would want to terminate a worker thread properly. It would obviously imply closing the socket from any other concurrent thread (since the thread running `accept()` can't do anything else)- and that can be the main thread too in principle. This issue here is of course as much a relevant one with the plain sync bindings run in any thread. It only remains as much, even with async execution support.

# Challenging ideas

## "Binding layer should do this"

We could have certainly solved this with [napi_create_async_work](https://nodejs.org/api/n-api.html#n_api_napi_create_async_work).

But that would have meant to basically rewrite the whole binding layer. The solution here is interesting by how little or nothing it adds to enable powerful usage.

To provide a natively asynchroneous I/O N-API binding layer for libSRT here is certainly a larger task we should envision for the future. 

It would in that case still be interesting to keep both native bindings (sync vs async at N-API layer) around, to see if there are pros/cons to implementing async I/O in either the way we do here via `Worker`, or via `napi_create_async_work`?

## "It would be simpler in main thread"

We can (actually *should*) keep the current sync'd binding layer around imo, with all the currently existing JS classes that are written directly on top of it to do scheduling tricks of the blocking I/O on the main thread (like the SRT-Readable/Writable classes here). It should be an interesting topic to see if we can optimize these for other cases too. It can be an interesting challenge as well to get the scheduling of these blocking tasks onto main loop execution timeframes right in order to keep it unblocked as much as possible. Both blocking vs async running bindings can exist side-by-side in this codebase and present different topics of research.

# A bit of JavaScript Theory

A bit about the theory here why this is needed (mostly have been writing this up to give myself a clear head about it): 

Conceptually for one, it is as far as "not a viable concept" for integrating with the JS ecosystem to run any blocking I/O on the main thread, where this environment specifically expects native/system-specific I/O calls to happen in background threads and leverage all advantages from that "async I/O". 

-On the other hand, JS does not allow to construct any main-loop-like concept (as in `while(true) { /* process some I/O event/message queue here */ }`); for the simple reason that it does not expose OS-level threads (as do Java or Python or other high-level (dynamic) runtimes). 

In JS there is just no way to do that, without causing congestion of internal event queuing of the very runtime by doing it (mostly as individual execution ticks take too long for upcoming other events to be processed). That very concept of an event-loop is built into the language or runtime this language specifies and thus expects. 

-So far for the theory :) 