### PR TITLE
Fix node-gyp rebuild script on Windows 

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "install": "npm run build-srt && npm run rebuild",
     "build-srt": "node scripts/build-srt-sdk.js",
-    "rebuild": "node-gyp rebuild -j $(echo \"console.log(require('os').cpus().length)\" | node)",
+    "rebuild": "node-gyp rebuild",
+    "rebuild-jn": "node-gyp rebuild -j $(echo \"console.log(require('os').cpus().length)\" | node)",
     "clean": "node-gyp clean",
     "test": "jasmine",
     "test-jest": "jest --runInBand --detectOpenHandles",

--- a/scripts/build-srt-sdk.js
+++ b/scripts/build-srt-sdk.js
@@ -44,10 +44,12 @@ if (!fs.existsSync(srtSourcePath)) {
 }
 
 function build() {
-  console.log('Building SRT SDK and prerequisites')
-  if (process.platform === "win32") {
+  console.log('Building SRT SDK and prerequisites for current platform:', process.platform);
+  switch (process.platform) {
+  case "win32":
     buildWin32();
-  } else {
+    break;
+  default:
     buildNx();
   }
 }


### PR DESCRIPTION
Adding that little magic that was setting `-j` to number of CPUs doesn't work there in the default shell unfortunately.

Therefore this patch makes it now `node-gyp rebuild`, while if you are on a unix like shell you can still use the `rebuild-jn` script which I added here with the previous part.