### PR TITLE
Fixed Windows build: using"diff" instead of patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "debug": "^4.1.1",
         "del": "^5.1.0",
+        "diff": "^5.1.0",
         "git-clone": "^0.1.0",
         "node-addon-api": "^5.0.0",
         "node-gyp": "^9.3.0"
@@ -2318,10 +2319,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -7049,6 +7049,15 @@
         "typescript": ">=2.7"
       }
     },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tslib": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
@@ -9405,10 +9414,9 @@
       "dev": true
     },
     "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw=="
     },
     "diff-sequences": {
       "version": "26.3.0",
@@ -13100,6 +13108,14 @@
         "make-error": "^1.1.1",
         "source-map-support": "^0.5.17",
         "yn": "3.1.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        }
       }
     },
     "tslib": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "debug": "^4.1.1",
     "del": "^5.1.0",
+    "diff": "^5.1.0",
     "git-clone": "^0.1.0",
     "node-addon-api": "^5.0.0",
     "node-gyp": "^9.3.0"

--- a/scripts/build-srt-sdk.js
+++ b/scripts/build-srt-sdk.js
@@ -4,6 +4,7 @@
 
 const path = require('path');
 const fs = require('fs');
+const jsdiff = require('diff');
 const process = require('process');
 const clone = require('git-clone');
 const del = require('del');
@@ -36,12 +37,21 @@ if (!fs.existsSync(srtSourcePath)) {
       if (fs.existsSync(srtSourcePath)) del.sync(srtSourcePath);
       process.exit(1);
     }
-    
     console.log("Patch build script");
-    const patch = spawnSync('patch', [ 'configure-data.tcl', '<', '../../scripts/configure-data.tcl.patch' ], { cwd: srtSourcePath, shell: true, stdio: 'inherit' });
-    if (patch.status) {
-      process.exit(patch.status);
-    }
+
+    // Read the source file and the patch file
+    const sourceFilePath = path.join(srtSourcePath, 'configure-data.tcl');
+    const patchFilePath = path.join(__dirname, 'configure-data.tcl.patch');
+
+    // Read the source file and the patch file
+    const sourceContent = fs.readFileSync(sourceFilePath, 'utf8');
+    const patchContent = fs.readFileSync(patchFilePath, 'utf8');
+
+    // Apply the patch
+    const patchedContent = jsdiff.applyPatch(sourceContent, patchContent);
+
+    // Write the patched content back to the source file
+    fs.writeFileSync(sourceFilePath, patchedContent, 'utf8');
 
     build();
   });


### PR DESCRIPTION
Due to node-srt depending on having ```patch``` installed on a system, the Windows build failed as it doesn't have ```patch```. 
As @Llorx suggested, this pull request uses the ```diff``` package in the build process. 

This should fix both #53 (patch has broken Windows installation) and #49 (Error while installing module). 