### PR TITLE
add event emitter to async class

### DIFF
--- a/src/async.js
+++ b/src/async.js
@@ -6,6 +6,7 @@ const debug = require('debug')('srt-async');
 
 const { traceCallToString, extractTransferListFromParams } = require('./async-helpers');
 const { SRT } = require('../build/Release/node_srt.node');
+const EventEmitter = require('events');
 
 const DEFAULT_PROMISE_TIMEOUT_MS = 3000;
 
@@ -15,7 +16,7 @@ const DEBUG = false;
 const WORK_ID_GEN_MOD = 0xFFF;
 */
 
-class AsyncSRT {
+class AsyncSRT extends EventEmitter {
 
   /**
    * @static
@@ -67,6 +68,7 @@ class AsyncSRT {
         '\n  Binding call:', traceCallToString(data.call.method, data.call.args),
         //'\n  Stacktrace:', data.err.stack
         );
+      this.emit('error', data.err.message)
       return;
     }
 


### PR DESCRIPTION
Related to issue https://github.com/Eyevinn/node-srt/issues/27 and to the use of AsyncSRT class. The class presently suppresses errors originating from the async worker, preventing users from capturing and managing them. If AsyncSRT incorporates EventEmitter, triggering an event upon encountering an error would empower users to address connection errors, such as re-initializing the AsyncSRT at the application level when connections suddenly end.