### PR TITLE
Fixes AsyncSRT types and tests, add super() to AsyncSRT constructor

### DIFF
--- a/src/async.js
+++ b/src/async.js
@@ -25,7 +25,7 @@ class AsyncSRT extends EventEmitter {
   static TimeoutMs = DEFAULT_PROMISE_TIMEOUT_MS;
 
   constructor() {
-
+    super()
     DEBUG && debug('Creating task-runner worker instance');
 
     this._worker = new Worker(path.resolve(__dirname, './async-worker.js'));

--- a/src/async.js
+++ b/src/async.js
@@ -6,6 +6,7 @@ const debug = require('debug')('srt-async');
 
 const { traceCallToString, extractTransferListFromParams } = require('./async-helpers');
 const { SRT } = require('../build/Release/node_srt.node');
+const EventEmitter = require('events');
 
 const DEFAULT_PROMISE_TIMEOUT_MS = 3000;
 
@@ -15,7 +16,7 @@ const DEBUG = false;
 const WORK_ID_GEN_MOD = 0xFFF;
 */
 
-class AsyncSRT {
+class AsyncSRT extends EventEmitter {
 
   /**
    * @static
@@ -67,6 +68,7 @@ class AsyncSRT {
         '\n  Binding call:', traceCallToString(data.call.method, data.call.args),
         //'\n  Stacktrace:', data.err.stack
         );
+      this.emit('error', data.err.message)
       return;
     }
 

--- a/types/srt-api-async.d.ts
+++ b/types/srt-api-async.d.ts
@@ -1,11 +1,11 @@
-
+import { EventEmitter } from "events";
 import { SRTLoggingLevel, SRTResult, SRTSockOpt, SRTSockStatus } from "../src/srt-api-enums";
 
 import { SRTReadReturn, SRTFileDescriptor, SRTEpollEvent, SRTSockOptValue, SRTStats } from "./srt-api"
 
 export type AsyncSRTCallback<T> = (result: T) => void;
 
-export class AsyncSRT {
+export class AsyncSRT extends EventEmitter {
 
   static TimeoutMs: number;
 


### PR DESCRIPTION
Event emitter type added to AsyncSRT types class and initialization of EventEmitter added to constructor of AsyncSRT. This should also fix the tests that are now failing.