### PR TITLE
Update SRT to 1.5.4 

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v3

--- a/scripts/build-srt-sdk.js
+++ b/scripts/build-srt-sdk.js
@@ -13,7 +13,7 @@ const os = require('os');
 const env = process.env;
 
 const SRT_REPO = env.NODE_SRT_REPO || "https://github.com/Haivision/srt.git";
-const SRT_CHECKOUT = "v1.5.2";
+const SRT_CHECKOUT = "v1.5.4";
 
 const srtRepoPath = env.NODE_SRT_LOCAL_REPO ? `file://${path.join(__dirname, env.NODE_SRT_LOCAL_REPO)}` : SRT_REPO;
 const srtCheckout = env.NODE_SRT_CHECKOUT || SRT_CHECKOUT;


### PR DESCRIPTION
Updates SRT to 1.5.4. Drop outdated NodeJS versions from build actions, especially because builds for NodeJS 14 might require complex adjustments.