### PR TITLE
allow setting int64_t based options by passing BigInt values

### DIFF
--- a/spec/srt_spec.js
+++ b/spec/srt_spec.js
@@ -1,4 +1,4 @@
-const { SRT } = require("../index.js");
+const { SRT } = require('../index.js');
 
 describe("SRT library", () => {
   it("exposes constants", () => {

--- a/spec/srt_spec.js
+++ b/spec/srt_spec.js
@@ -1,4 +1,4 @@
-const { SRT } = require('../index.js');
+const { SRT } = require("../index.js");
 
 describe("SRT library", () => {
   it("exposes constants", () => {
@@ -77,5 +77,13 @@ describe("SRT library", () => {
   it("exposes socket options", () => {
     expect(SRT.SRTO_UDP_SNDBUF).toEqual(8);
     expect(SRT.SRTO_RCVLATENCY).toEqual(43);
+  });
+
+  it("can set and get maxbw as bigint", () => {
+    const srt = new SRT();
+    const socket = srt.createSocket();
+    srt.setSockOpt(socket, SRT.SRTO_MAXBW, 1000000n);
+    const set = srt.getSockOpt(socket, SRT.SRTO_MAXBW);
+    expect(set).toEqual(1000000n);
   });
 });

--- a/src/node-srt.cc
+++ b/src/node-srt.cc
@@ -388,14 +388,11 @@ Napi::Value NodeSRT::GetSockOpt(const Napi::CallbackInfo& info) {
     case SRTO_PASSPHRASE:
     case SRTO_STREAMID:
     {
-      char optValue[512] = {0};
-      int optSize = sizeof(optValue) - 1;
+      char optValue[512];
+      int optSize = sizeof(optValue);
       result = srt_getsockflag(socketValue, (SRT_SOCKOPT)optName, (void *)&optValue, &optSize);
-      if (result == SRT_ERROR) {
-        Napi::TypeError::New(env, "Failed to get SRT socket option").ThrowAsJavaScriptException();
-        return env.Undefined();
-      }
-      returnVal = Napi::Value::From(env, std::string(optValue, static_cast<size_t>(optSize)));
+
+      returnVal = Napi::Value::From(env, std::string(optValue));
       break;
     }
     default:

--- a/src/node-srt.cc
+++ b/src/node-srt.cc
@@ -249,7 +249,26 @@ Napi::Value NodeSRT::SetSockOpt(const Napi::CallbackInfo& info) {
   Napi::Number option = info[1].As<Napi::Number>();
   int result = SRT_ERROR;
 
-  if (info[2].IsNumber()) {
+  if (info[2].IsEmpty()) {
+      Napi::TypeError::New(env, "Value is empty").ThrowAsJavaScriptException();
+      return env.Undefined();
+  }
+
+  if (info[2].IsBigInt()) {
+    Napi::BigInt value = info[2].As<Napi::BigInt>();
+    int32_t optName = option;
+    bool lossless = true;
+    int64_t optValue = value.Int64Value(&lossless);
+    if (!lossless) {
+      Napi::Error::New(env, "BigInt value overflows int64_t").ThrowAsJavaScriptException();
+      return Napi::Number::New(env, SRT_ERROR);
+    }
+    result = srt_setsockflag(socketValue, (SRT_SOCKOPT) optName, &optValue, sizeof(int64_t));
+    if (result == SRT_ERROR) {
+      Napi::Error::New(env, srt_getlasterror_str()).ThrowAsJavaScriptException();
+      return Napi::Number::New(env, SRT_ERROR);
+    }
+  } else if (info[2].IsNumber()) {
     Napi::Number value = info[2].As<Napi::Number>();
     int32_t optName = option;
     int optValue = value;
@@ -296,11 +315,24 @@ Napi::Value NodeSRT::GetSockOpt(const Napi::CallbackInfo& info) {
   int result = SRT_ERROR;
 
   switch((SRT_SOCKOPT)optName) {
+    case SRTO_INPUTBW:
+    case SRTO_MAXBW:
+    case SRTO_MININPUTBW:
+    {
+      int64_t optValue = 0;
+      int optSize = sizeof(optValue);
+      result = srt_getsockflag(socketValue, (SRT_SOCKOPT)optName, (void *)&optValue, &optSize);
+      if (result == SRT_ERROR) {
+        Napi::TypeError::New(env, "Failed to get SRT bandwidth option").ThrowAsJavaScriptException();
+        return env.Undefined();
+      }
+      returnVal = Napi::BigInt::New(env, optValue);
+      break;
+    }
     case SRTO_MSS:
     case SRTO_CONNTIMEO:
     case SRTO_EVENT:
     case SRTO_FC:
-    case SRTO_INPUTBW:
     case SRTO_IPTOS:
     case SRTO_ISN:
     case SRTO_IPTTL:
@@ -310,7 +342,6 @@ Napi::Value NodeSRT::GetSockOpt(const Napi::CallbackInfo& info) {
     case SRTO_KMSTATE:
     case SRTO_LATENCY:
     case SRTO_LOSSMAXTTL:
-    case SRTO_MAXBW:
     case SRTO_MINVERSION:
     case SRTO_OHEADBW:
     case SRTO_PAYLOADSIZE:
@@ -357,11 +388,14 @@ Napi::Value NodeSRT::GetSockOpt(const Napi::CallbackInfo& info) {
     case SRTO_PASSPHRASE:
     case SRTO_STREAMID:
     {
-      char optValue[512];
-      int optSize = sizeof(optValue);
+      char optValue[512] = {0};
+      int optSize = sizeof(optValue) - 1;
       result = srt_getsockflag(socketValue, (SRT_SOCKOPT)optName, (void *)&optValue, &optSize);
-
-      returnVal = Napi::Value::From(env, std::string(optValue));
+      if (result == SRT_ERROR) {
+        Napi::TypeError::New(env, "Failed to get SRT socket option").ThrowAsJavaScriptException();
+        return env.Undefined();
+      }
+      returnVal = Napi::Value::From(env, std::string(optValue, static_cast<size_t>(optSize)));
       break;
     }
     default:


### PR DESCRIPTION
Several options expect int64_t values to be set, like SRTO_MAXBW. Extended SetSocketOpt to accept BigInt values.