### PR TITLE
ci: run CI on pull_request events (cover fork PRs)

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,8 @@
 name: Node CI
-  
-on: [push]
+
+on:
+  push:
+  pull_request:
 
 jobs:
   build-linux:
@@ -49,4 +51,4 @@ jobs:
 #        npm test
 #      env:
 #        CI: true
-  
+


### PR DESCRIPTION
## Problem

The Node CI workflow triggers on `on: [push]` only. A `push` event for a PR opened from a **fork** fires in the contributor's fork, not in this repo — and with no `pull_request` trigger, `Eyevinn/node-srt` never runs CI for fork PRs. The result is that external contributions show **"no checks reported"** (e.g. #77, #78), while a PR from an in-repo branch (#76) gets CI purely because its branch lives here. Every external contributor's build currently goes unverified — on a native addon where the build is the risky part.

## Fix

Add a `pull_request` trigger so the build/test matrix runs for PRs, including those from forks:

```yaml
on:
  push:
  pull_request:
```

`pull_request` (not `pull_request_target`) checks out the PR's code with a **read-only** `GITHUB_TOKEN` and **no access to secrets**, which is the safe default for a build/test job on untrusted fork code. No job steps change.

## Scope

CI-config only — no runtime, native, or build-script changes.

---
_Opened by the node-srt community triage bot (CI-config fix). Once CI is green here, this is a Tier A change that can be merged._