### PR TITLE
fix: Accept() must not close the listener socket on success

### DIFF
--- a/spec/accept_keeps_listener_open_spec.js
+++ b/spec/accept_keeps_listener_open_spec.js
@@ -1,0 +1,68 @@
+const { SRT, AsyncSRT } = require('../index.js');
+
+// Regression test for https://github.com/Eyevinn/node-srt/issues/79
+//
+// NodeSRT::Accept() used to call srt_close() on the listener socket on the
+// success path, so the listener could only ever accept a single connection
+// before going BROKEN. These tests accept several connections in a row from
+// the same listener and assert it stays LISTENING throughout, for both the
+// sync (SRT) and async (AsyncSRT) accept paths.
+
+describe("Accept() must not close the listener socket", () => {
+  const numConnections = 3;
+
+  it("keeps a sync (SRT) listener open across multiple sequential accepts", async () => {
+    const srt = new SRT();
+    const listenerFd = srt.createSocket();
+    srt.bind(listenerFd, "0.0.0.0", 1350);
+    srt.listen(listenerFd, 8);
+
+    // Drives the connecting side off the main thread so the blocking
+    // srt.accept() call below can be unblocked by an in-flight connect.
+    const asyncClient = new AsyncSRT();
+
+    for (let i = 0; i < numConnections; i++) {
+      const clientFd = await asyncClient.createSocket();
+      const connectPromise = asyncClient.connect(clientFd, "127.0.0.1", 1350);
+
+      const acceptedFd = srt.accept(listenerFd);
+
+      expect(acceptedFd).not.toEqual(SRT.ERROR);
+      expect(srt.getSockState(listenerFd)).toEqual(SRT.SRTS_LISTENING);
+
+      await connectPromise;
+      srt.close(acceptedFd);
+      await asyncClient.close(clientFd);
+    }
+
+    srt.close(listenerFd);
+    await asyncClient.dispose();
+  });
+
+  it("keeps an async (AsyncSRT) listener open across multiple sequential accepts", async () => {
+    const asyncServer = new AsyncSRT();
+    const asyncClient = new AsyncSRT();
+
+    const listenerFd = await asyncServer.createSocket();
+    await asyncServer.bind(listenerFd, "0.0.0.0", 1351);
+    await asyncServer.listen(listenerFd, 8);
+
+    for (let i = 0; i < numConnections; i++) {
+      const clientFd = await asyncClient.createSocket();
+      const connectPromise = asyncClient.connect(clientFd, "127.0.0.1", 1351);
+
+      const acceptedFd = await asyncServer.accept(listenerFd);
+
+      expect(acceptedFd).not.toEqual(SRT.ERROR);
+      expect(await asyncServer.getSockState(listenerFd)).toEqual(SRT.SRTS_LISTENING);
+
+      await connectPromise;
+      await asyncServer.close(acceptedFd);
+      await asyncClient.close(clientFd);
+    }
+
+    await asyncServer.close(listenerFd);
+    await asyncServer.dispose();
+    await asyncClient.dispose();
+  });
+});

--- a/src/node-srt.cc
+++ b/src/node-srt.cc
@@ -177,8 +177,6 @@ Napi::Value NodeSRT::Accept(const Napi::CallbackInfo& info) {
     Napi::Error::New(env, srt_getlasterror_str()).ThrowAsJavaScriptException();
     return Napi::Number::New(env, SRT_ERROR);
   }
-  srt_close(socketValue);
-  socketValue = Napi::Number::New(env, SRT_INVALID_SOCK);
   return Napi::Number::New(env, their_fd);
 }
 


### PR DESCRIPTION
## Summary

`NodeSRT::Accept()` (`src/node-srt.cc`) called `srt_close()` on the **listener** socket on the success path, so the listener was destroyed after every accepted connection.

In libsrt, `srt_accept()` returns the newly accepted socket and leaves the listener open so it can keep accepting - this diverged from that contract:

- A server could accept only one connection per listener; after the first `accept()` the listener went `BROKEN` then `NONEXIST`, and any further caller timed out.
- The usual workaround, re-creating (bind+listen) the listener after every accept, drops its backlog of pending handshakes. Under a burst of simultaneous callers this meant only one connection got through and the rest failed.

## Fix

Removes the success-path `srt_close(socketValue)` (and the following no-op reassignment), so `Accept()` only returns the accepted fd and leaves the listener open, matching libsrt semantics. The caller is responsible for closing the listener when done. The failure path is unchanged.

## Test

Adds `spec/accept_keeps_listener_open_spec.js`, a regression test covering both the sync (`SRT`) and async (`AsyncSRT`) accept paths: it accepts several connections in a row from the same listener and asserts the listener stays `LISTENING` throughout.

Verified locally:
- Reverting just the `src/node-srt.cc` change and rebuilding the addon reproduces the bug: the listener's state goes `BROKEN` right after the first accept, and the next connection attempt errors out (`invalid listener socket ID value`).
- With the fix applied, the full spec suite passes (23/23), including the new test.

Fixes #79

cc @birme